### PR TITLE
Support adding arbitrary values to settings.py

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,10 @@
 #   (string) Defaults to 'private' If set to 'public' puppetboard will listen
 #   on 0.0.0.0; otherwise it will only be accessible via localhost.
 #
+# [*extra_settings*]
+#   (hash) Defaults to an empty hash '{}'. Used to pass in arbitrary key/value
+#   pairs that are added to settings.py
+#
 # === Examples
 #
 #  class { 'puppetboard':
@@ -159,10 +163,12 @@ class puppetboard(
   $manage_virtualenv   = false,
   $reports_count       = $::puppetboard::params::reports_count,
   $listen              = $::puppetboard::params::listen,
+  $extra_settings      = $::puppetboard::params::extra_settings,
 ) inherits ::puppetboard::params {
   validate_bool($enable_query)
   validate_bool($experimental)
   validate_bool($localise_timestamp)
+  validate_hash($extra_settings)
 
   if $manage_group {
     group { $group:
@@ -217,6 +223,7 @@ class puppetboard(
   #$puppetdb_ssl_verify
   #$puppetdb_timeout
   #$unresponsive
+  #$extra_settings
   file {"${basedir}/puppetboard/settings.py":
     ensure  => 'file',
     group   => $group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,4 +42,5 @@ class puppetboard::params {
   $revision = undef
   $virtualenv = 'python-virtualenv'
   $listen = 'private'
+  $extra_settings = {}
 }

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -48,3 +48,6 @@ PUPPETDB_EXPERIMENTAL = False
 <% if @reports_count -%>
 REPORTS_COUNT = <%= @reports_count %>
 <% end -%>
+<% @extra_settings.each_pair do |key, value| -%>
+<%= key %> = <%= value %>
+<% end -%>


### PR DESCRIPTION
This change makes it possible to add arbitrary additional values to ```settings.py```.

For example:
```puppet
class{'puppetboard':
  # other parameters
  extra_settings => {
    NODES_FACTS = "['some_fact', 'some_other_fact']"
  },
}
```

This would result in the following being added to ```settings.py```:
```python
NODES_FACTS = ['some_fact', 'some_other_fact']
```

It was written to work with [@vjanelle's PR](https://github.com/puppet-community/puppetboard/pull/108) to puppetboard which supports adding arbitrary fact values in the tables on the overview and nodes pages of puppetboard

