### PR TITLE
fix order so repo is created before file permissions are applied

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,6 +208,7 @@ class puppetboard(
   file { "${basedir}/puppetboard":
     owner   => $user,
     recurse => true,
+    require => Vcsrepo["${basedir}/puppetboard"],
   }
 
   #Template consumes:


### PR DESCRIPTION
On new module install basedir/puppetboard is created as an empty file and vcsrepo
fails with: "fatal: destination path '/srv/puppetboard/puppetboard'
already exists and is not an empty directory."

A require fixed it for me and puppetboard installed flawlessly.