### PR TITLE
Require Vcsrepo[$dcroot] for wsgi.py file creation

### DIFF
--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -52,7 +52,10 @@ class puppetboard::apache::conf (
     content => template('puppetboard/wsgi.py.erb'),
     owner   => $user,
     group   => $group,
-    require => User[$user],
+    require => [
+      User[$user],
+      Vcsrepo[$docroot],
+    ],
   }
 
   # Template Uses:

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -65,7 +65,10 @@ class puppetboard::apache::vhost (
     content => template('puppetboard/wsgi.py.erb'),
     owner   => $user,
     group   => $group,
-    require => User[$user],
+    require => [
+      User[$user],
+      Vcsrepo[$docroot],
+    ],
   }
 
   ::apache::vhost { $vhost_name:


### PR DESCRIPTION
This resolves a problem that I ran into where file { "${docroot}/wsgi.py"} wanted to be created but Vcsreop[$docroot] didn't exist yet.