### PR TITLE
Adding the selinux setup to allow this to work on RHEL with selinux e…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,22 @@ class puppetboard::params {
     'RedHat': {
       $apache_confd   = '/etc/httpd/conf.d'
       $apache_service = 'httpd'
+      File {
+        seltype => 'httpd_sys_content_t',
+      }
+      selboolean {'httpd_can_network_relay' :
+        presistent => true,
+        value      => 1,
+      }
+      selboolean {'httpd_can_network_connect' :
+        presistent => true,
+        value      => 1,
+      }
+      selboolean {'httpd_can_network_db' :
+        presistent => true,
+        value      => 1,
+      }
+
     }
     default: { fail("The ${::osfamily} operating system is not supported with the puppetboard module") }
   }


### PR DESCRIPTION
Setup Selinux on RHEL servers to enable PuppetBoard to function on install