### PR TITLE
Correct selboolean value for selinux on RedHat osfamily.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class puppetboard::params {
         persistent => true,
         value      => 'on',
       }
-      selboolean {'httpd_can_network_db' :
+      selboolean {'httpd_can_network_connect_db' :
         persistent => true,
         value      => 'on',
       }


### PR DESCRIPTION
Changes "httpd_can_network_db" to "http_can_network_connect_db".  Tested on CentOS 7.1.  Fixes error message "Error: /Stage[main]/Puppetboard::Params/Selboolean[httpd_can_network_db]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_network_db' returned 255: Error getting active value for httpd_can_network_db".