### PR TITLE
The process must match the group

### DIFF
--- a/templates/apache/conf.erb
+++ b/templates/apache/conf.erb
@@ -2,7 +2,7 @@ WSGIDaemonProcess puppetboard user=<%= @user -%> group=<%= @user -%> threads=<%=
 WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
 
 <Directory <%= @docroot -%>>
-    WSGIProcessGroup <%= @user %>
+    WSGIProcessGroup puppetboard
     WSGIApplicationGroup %{GLOBAL}
     Order deny,allow
     Allow from all


### PR DESCRIPTION
I got burned by this; I kept getting this error.

http://stackoverflow.com/questions/2113905/cannot-solve-mod-wsgi-exception-in-django-setup

The user is only needed in the process as user=, not the group.